### PR TITLE
Fix multiple-character handles

### DIFF
--- a/src/Shuble/Slurpy/Factory.php
+++ b/src/Shuble/Slurpy/Factory.php
@@ -367,6 +367,6 @@ class Factory
      */
     protected function generateFileHandle($index)
     {
-        return chr(65 + floor($index/26) % 26) . chr(65 + $index % 26);
+        return (($index >= 26) ? chr(65 + (floor($index / 26) - 1) % 26) : '') . chr(65 + $index % 26);
     }
 }


### PR DESCRIPTION
This PR implements a non-BC change to support older versions (fixes #1 and replaces #4). With this fix, newer versions can handle up to 702 files whereas users with an older version of pdftk are limited to 26 files.

Generated file handles: A, B, ..., Z, AA, AB, ..., ZZ

We should probably add a small note in the code or README about the fact that older versions of pdftk are unable to handle many files.
